### PR TITLE
Mark Temporal Replay 2026 talk as rejected

### DIFF
--- a/content/talks/crawl-wait-signal-temporal-replay-2026.md
+++ b/content/talks/crawl-wait-signal-temporal-replay-2026.md
@@ -8,9 +8,10 @@ readTime: true
 autonumber: false
 math: false
 draft: false
+status: "rejected"
 ---
 
-> Submitted for Temporal Replay 2026.
+> Submitted for Temporal Replay 2026. **Rejected.**
 
 ## Title (100 chars)
 


### PR DESCRIPTION
## Summary
- Adds `status: "rejected"` to the frontmatter of the Temporal Replay 2026 talk proposal
- Updates the submission note to indicate rejection

## Test plan
- [ ] Verify the talk page renders correctly with the updated status

🤖 Generated with [Claude Code](https://claude.com/claude-code)