### PR TITLE
Add AI agent telemetry dashboard to /ai page

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -1,0 +1,339 @@
+/* ── Sigil: AI telemetry panel ── */
+
+:root {
+  --sigil-claude: #d97706;
+  --sigil-openclaw: #7c3aed;
+  --sigil-codex: #059669;
+  --sigil-muted: var(--content-secondary);
+  --sigil-border: var(--code-border);
+  --sigil-surface: var(--code-background);
+}
+
+.sigil-panel {
+  margin-top: 2rem;
+}
+
+.sigil-section-label {
+  font-family: var(--font-mono);
+  font-size: 0.75em;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--sigil-muted);
+  margin-bottom: 0.25rem;
+}
+
+.sigil-subtitle {
+  color: var(--sigil-muted);
+  font-size: 0.9em;
+  margin-top: 0;
+  margin-bottom: 1.5rem;
+}
+
+/* ── Pulse: summary stats ── */
+
+.sigil-pulse {
+  margin-bottom: 2rem;
+}
+
+.sigil-pulse-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 1rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--sigil-border);
+}
+
+.sigil-pulse-label {
+  font-family: var(--font-mono);
+  font-size: 0.8em;
+  font-weight: bold;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.sigil-pulse-period {
+  font-family: var(--font-mono);
+  font-size: 0.75em;
+  color: var(--sigil-muted);
+}
+
+.sigil-stats-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.sigil-stat {
+  text-align: center;
+  flex: 1;
+}
+
+.sigil-stat-value {
+  font-family: var(--font-mono);
+  font-size: 1.4em;
+  font-weight: bold;
+  display: block;
+  line-height: 1.2;
+}
+
+.sigil-stat-label {
+  font-family: var(--font-mono);
+  font-size: 0.65em;
+  color: var(--sigil-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+/* ── Activity sparkline bar chart ── */
+
+.sigil-spark {
+  margin-bottom: 1.5rem;
+}
+
+.sigil-spark-bars {
+  display: flex;
+  align-items: flex-end;
+  gap: 2px;
+  height: 48px;
+  padding: 0 1px;
+}
+
+.sigil-spark-bar {
+  flex: 1;
+  min-width: 0;
+  height: var(--h, 0%);
+  background: var(--sigil-claude);
+  border-radius: 2px 2px 0 0;
+  opacity: 0.8;
+}
+
+.sigil-spark-bar.sigil-spark-zero {
+  height: 2px;
+  background: var(--sigil-border);
+  opacity: 0.5;
+}
+
+.sigil-spark-labels {
+  display: flex;
+  justify-content: space-between;
+  font-family: var(--font-mono);
+  font-size: 0.6em;
+  color: var(--sigil-muted);
+  margin-top: 0.3rem;
+  padding: 0 1px;
+}
+
+/* ── Agent bars ── */
+
+.sigil-agents {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.sigil-agent-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-family: var(--font-mono);
+  font-size: 0.8em;
+}
+
+.sigil-agent-name {
+  min-width: 100px;
+  text-align: right;
+  white-space: nowrap;
+}
+
+.sigil-agent-bar-track {
+  flex: 1;
+  height: 8px;
+  background: var(--sigil-surface);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.sigil-agent-bar-fill {
+  height: 100%;
+  border-radius: 4px;
+  transition: width 0.3s;
+}
+
+.sigil-agent-bar-fill.claude_code { background: var(--sigil-claude); }
+.sigil-agent-bar-fill.openclaw { background: var(--sigil-openclaw); }
+.sigil-agent-bar-fill.codex { background: var(--sigil-codex); }
+
+.sigil-agent-pct {
+  min-width: 36px;
+  color: var(--sigil-muted);
+  font-size: 0.85em;
+  text-align: right;
+}
+
+/* ── Numbers section ── */
+
+.sigil-numbers {
+  margin-bottom: 2rem;
+}
+
+.sigil-numbers-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.sigil-number-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  padding: 0.4rem 0;
+  border-bottom: 1px solid var(--sigil-border);
+  font-size: 0.9em;
+}
+
+.sigil-number-row:last-child {
+  border-bottom: none;
+}
+
+.sigil-number-key {
+  font-family: var(--font-mono);
+  font-size: 0.8em;
+  color: var(--sigil-muted);
+}
+
+.sigil-number-val {
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  font-weight: bold;
+  text-align: right;
+}
+
+/* ── Tools section ── */
+
+.sigil-tools {
+  margin-bottom: 2rem;
+}
+
+.sigil-tools-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1rem;
+  margin-top: 0.75rem;
+}
+
+.sigil-tool-card {
+  border: 1px solid var(--sigil-border);
+  border-radius: 8px;
+  padding: 1rem;
+}
+
+.sigil-tool-card-header {
+  font-family: var(--font-mono);
+  font-size: 0.8em;
+  font-weight: bold;
+  margin-bottom: 0.5rem;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.sigil-tool-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  display: inline-block;
+  flex-shrink: 0;
+}
+
+.sigil-tool-dot.claude_code { background: var(--sigil-claude); }
+.sigil-tool-dot.openclaw { background: var(--sigil-openclaw); }
+.sigil-tool-dot.codex { background: var(--sigil-codex); }
+
+.sigil-tool-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.sigil-tool-list li {
+  display: flex;
+  justify-content: space-between;
+  font-family: var(--font-mono);
+  font-size: 0.72em;
+  padding: 0.15rem 0;
+  margin-left: 0;
+  color: var(--sigil-muted);
+}
+
+.sigil-tool-list li span:first-child {
+  color: var(--content-primary);
+}
+
+/* ── Observations ── */
+
+.sigil-observations {
+  margin-bottom: 2rem;
+}
+
+.sigil-observations-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  margin-top: 0.5rem;
+}
+
+.sigil-observations-list li {
+  margin-left: 0;
+  padding: 0.35rem 0;
+  font-size: 0.85em;
+  line-height: 1.5;
+  border-bottom: 1px solid var(--sigil-border);
+}
+
+.sigil-observations-list li:last-child {
+  border-bottom: none;
+}
+
+.sigil-obs-marker {
+  font-family: var(--font-mono);
+  color: var(--sigil-muted);
+  margin-right: 0.4rem;
+  font-size: 0.85em;
+}
+
+/* ── Footer ── */
+
+.sigil-footer {
+  margin-top: 1.5rem;
+  margin-bottom: 0;
+  font-family: var(--font-mono);
+  font-size: 0.65em;
+  color: var(--sigil-muted);
+  text-align: center;
+}
+
+/* ── Responsive ── */
+
+@media screen and (max-width: 640px) {
+  .sigil-stats-row {
+    flex-wrap: wrap;
+  }
+
+  .sigil-stat {
+    flex: 0 0 calc(50% - 0.5rem);
+  }
+
+  .sigil-agent-row {
+    font-size: 0.75em;
+  }
+
+  .sigil-agent-name {
+    min-width: 80px;
+  }
+
+  .sigil-tools-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -1,339 +1,148 @@
-/* ── Sigil: AI telemetry panel ── */
+/* ── Sigil: AI telemetry panel (terminal aesthetic) ── */
 
-:root {
-  --sigil-claude: #d97706;
-  --sigil-openclaw: #7c3aed;
-  --sigil-codex: #059669;
-  --sigil-muted: var(--content-secondary);
-  --sigil-border: var(--code-border);
-  --sigil-surface: var(--code-background);
-}
-
-.sigil-panel {
+.sigil {
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  line-height: 1.7;
   margin-top: 2rem;
 }
 
-.sigil-section-label {
-  font-family: var(--font-mono);
-  font-size: 0.75em;
-  letter-spacing: 0.1em;
+.sigil-heading {
+  font-size: 1.1em;
+  font-weight: bold;
+  letter-spacing: 0.05em;
   text-transform: uppercase;
-  color: var(--sigil-muted);
-  margin-bottom: 0.25rem;
+  margin-bottom: 0.1rem;
 }
 
-.sigil-subtitle {
-  color: var(--sigil-muted);
-  font-size: 0.9em;
+.sigil-sub {
+  color: var(--content-secondary);
   margin-top: 0;
   margin-bottom: 1.5rem;
 }
 
-/* ── Pulse: summary stats ── */
-
-.sigil-pulse {
-  margin-bottom: 2rem;
-}
-
-.sigil-pulse-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: baseline;
-  margin-bottom: 1rem;
-  padding-bottom: 0.5rem;
-  border-bottom: 1px solid var(--sigil-border);
-}
-
-.sigil-pulse-label {
-  font-family: var(--font-mono);
-  font-size: 0.8em;
-  font-weight: bold;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-}
-
-.sigil-pulse-period {
-  font-family: var(--font-mono);
-  font-size: 0.75em;
-  color: var(--sigil-muted);
-}
-
-.sigil-stats-row {
-  display: flex;
-  justify-content: space-between;
-  gap: 1rem;
-  margin-bottom: 1.5rem;
-}
-
-.sigil-stat {
-  text-align: center;
-  flex: 1;
-}
-
-.sigil-stat-value {
-  font-family: var(--font-mono);
-  font-size: 1.4em;
-  font-weight: bold;
-  display: block;
-  line-height: 1.2;
-}
-
-.sigil-stat-label {
-  font-family: var(--font-mono);
-  font-size: 0.65em;
-  color: var(--sigil-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-}
-
-/* ── Activity sparkline bar chart ── */
-
-.sigil-spark {
-  margin-bottom: 1.5rem;
-}
-
-.sigil-spark-bars {
-  display: flex;
-  align-items: flex-end;
-  gap: 2px;
-  height: 48px;
-  padding: 0 1px;
-}
-
-.sigil-spark-bar {
-  flex: 1;
-  min-width: 0;
-  height: var(--h, 0%);
-  background: var(--sigil-claude);
-  border-radius: 2px 2px 0 0;
-  opacity: 0.8;
-}
-
-.sigil-spark-bar.sigil-spark-zero {
-  height: 2px;
-  background: var(--sigil-border);
-  opacity: 0.5;
-}
-
-.sigil-spark-labels {
-  display: flex;
-  justify-content: space-between;
-  font-family: var(--font-mono);
-  font-size: 0.6em;
-  color: var(--sigil-muted);
-  margin-top: 0.3rem;
-  padding: 0 1px;
-}
-
-/* ── Agent bars ── */
-
-.sigil-agents {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-  margin-bottom: 0.5rem;
-}
-
-.sigil-agent-row {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  font-family: var(--font-mono);
-  font-size: 0.8em;
-}
-
-.sigil-agent-name {
-  min-width: 100px;
-  text-align: right;
+.sigil-divider {
+  color: var(--content-secondary);
+  margin: 1.5rem 0 0.75rem;
+  overflow: hidden;
   white-space: nowrap;
 }
 
-.sigil-agent-bar-track {
-  flex: 1;
-  height: 8px;
-  background: var(--sigil-surface);
-  border-radius: 4px;
-  overflow: hidden;
-}
-
-.sigil-agent-bar-fill {
-  height: 100%;
-  border-radius: 4px;
-  transition: width 0.3s;
-}
-
-.sigil-agent-bar-fill.claude_code { background: var(--sigil-claude); }
-.sigil-agent-bar-fill.openclaw { background: var(--sigil-openclaw); }
-.sigil-agent-bar-fill.codex { background: var(--sigil-codex); }
-
-.sigil-agent-pct {
-  min-width: 36px;
-  color: var(--sigil-muted);
-  font-size: 0.85em;
-  text-align: right;
-}
-
-/* ── Numbers section ── */
-
-.sigil-numbers {
-  margin-bottom: 2rem;
-}
-
-.sigil-numbers-list {
-  display: flex;
-  flex-direction: column;
-}
-
-.sigil-number-row {
+.sigil-row {
   display: flex;
   justify-content: space-between;
   align-items: baseline;
-  padding: 0.4rem 0;
-  border-bottom: 1px solid var(--sigil-border);
-  font-size: 0.9em;
 }
 
-.sigil-number-row:last-child {
-  border-bottom: none;
+.sigil-muted {
+  color: var(--content-secondary);
 }
 
-.sigil-number-key {
-  font-family: var(--font-mono);
-  font-size: 0.8em;
-  color: var(--sigil-muted);
+.sigil-stats {
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  margin: 0.75rem 0 1.25rem;
+  font-size: 1.3em;
 }
 
-.sigil-number-val {
-  font-family: var(--font-mono);
-  font-size: 0.85em;
-  font-weight: bold;
+.sigil-stats span {
+  white-space: nowrap;
+}
+
+.sigil-stats strong {
+  margin-right: 0.2em;
+}
+
+/* Sparkline rendered with unicode blocks */
+.sigil-spark {
+  letter-spacing: -0.02em;
+  color: var(--content-secondary);
+  margin: 0.25rem 0 0.5rem;
+}
+
+.sigil-spark-row {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.75em;
+  color: var(--content-secondary);
+  margin-top: 0.1rem;
+}
+
+/* Agent bars with block chars */
+.sigil-bar-section {
+  margin: 0.5rem 0;
+}
+
+.sigil-bar-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75em;
+  white-space: nowrap;
+}
+
+.sigil-bar-label {
+  min-width: 11ch;
   text-align: right;
 }
 
-/* ── Tools section ── */
-
-.sigil-tools {
-  margin-bottom: 2rem;
+.sigil-bar-track {
+  flex: 1 1 auto;
+  height: 10px;
+  background: #e0e0e0;
 }
 
-.sigil-tools-grid {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 1rem;
-  margin-top: 0.75rem;
+.sigil-bar-fill {
+  height: 10px;
+  background: #222;
 }
 
-.sigil-tool-card {
-  border: 1px solid var(--sigil-border);
-  border-radius: 8px;
-  padding: 1rem;
+.sigil-bar-pct {
+  color: var(--content-secondary);
+  min-width: 4ch;
+  text-align: center;
 }
 
-.sigil-tool-card-header {
-  font-family: var(--font-mono);
-  font-size: 0.8em;
-  font-weight: bold;
-  margin-bottom: 0.5rem;
-  display: flex;
-  align-items: center;
-  gap: 0.4rem;
+/* Numbers: key left, value right */
+.sigil-numbers {
+  margin: 0.5rem 0;
 }
 
-.sigil-tool-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  display: inline-block;
-  flex-shrink: 0;
-}
-
-.sigil-tool-dot.claude_code { background: var(--sigil-claude); }
-.sigil-tool-dot.openclaw { background: var(--sigil-openclaw); }
-.sigil-tool-dot.codex { background: var(--sigil-codex); }
-
-.sigil-tool-list {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-}
-
-.sigil-tool-list li {
+.sigil-num-row {
   display: flex;
   justify-content: space-between;
+  align-items: baseline;
+}
+
+.sigil-num-row span {
+  color: var(--content-secondary);
+}
+
+/* Observations */
+.sigil-obs {
+  margin: 0.5rem 0;
+}
+
+.sigil-obs p {
   font-family: var(--font-mono);
-  font-size: 0.72em;
-  padding: 0.15rem 0;
-  margin-left: 0;
-  color: var(--sigil-muted);
+  font-size: 0.95em;
+  margin: 0.3rem 0;
+  line-height: 1.6;
 }
-
-.sigil-tool-list li span:first-child {
-  color: var(--content-primary);
-}
-
-/* ── Observations ── */
-
-.sigil-observations {
-  margin-bottom: 2rem;
-}
-
-.sigil-observations-list {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  margin-top: 0.5rem;
-}
-
-.sigil-observations-list li {
-  margin-left: 0;
-  padding: 0.35rem 0;
-  font-size: 0.85em;
-  line-height: 1.5;
-  border-bottom: 1px solid var(--sigil-border);
-}
-
-.sigil-observations-list li:last-child {
-  border-bottom: none;
-}
-
-.sigil-obs-marker {
-  font-family: var(--font-mono);
-  color: var(--sigil-muted);
-  margin-right: 0.4rem;
-  font-size: 0.85em;
-}
-
-/* ── Footer ── */
 
 .sigil-footer {
   margin-top: 1.5rem;
   margin-bottom: 0;
-  font-family: var(--font-mono);
-  font-size: 0.65em;
-  color: var(--sigil-muted);
-  text-align: center;
+  font-size: 0.75em;
+  color: var(--content-secondary);
 }
 
-/* ── Responsive ── */
-
 @media screen and (max-width: 640px) {
-  .sigil-stats-row {
-    flex-wrap: wrap;
+  .sigil-stats {
+    gap: 1rem;
   }
 
-  .sigil-stat {
-    flex: 0 0 calc(50% - 0.5rem);
-  }
-
-  .sigil-agent-row {
-    font-size: 0.75em;
-  }
-
-  .sigil-agent-name {
-    min-width: 80px;
-  }
-
-  .sigil-tools-grid {
-    grid-template-columns: 1fr;
+  .sigil-bar-label {
+    min-width: 9ch;
   }
 }

--- a/content/ai.md
+++ b/content/ai.md
@@ -1,10 +1,151 @@
 ---
-title: "AI Policy"
+title: "AI"
 toc: false
 readTime: false
 math: false
 draft: false
+hidePagination: true
 ---
+
+{{< rawhtml >}}
+<div class="sigil-panel">
+
+  <p class="sigil-section-label">The Agent Log</p>
+  <p class="sigil-subtitle">A live view of everything I'm building with AI agents.</p>
+
+  <div class="sigil-pulse">
+    <div class="sigil-pulse-header">
+      <span class="sigil-pulse-label">The Pulse</span>
+      <span class="sigil-pulse-period">last 30 days</span>
+    </div>
+
+    <div class="sigil-stats-row">
+      <div class="sigil-stat">
+        <span class="sigil-stat-value">147</span>
+        <span class="sigil-stat-label">sessions</span>
+      </div>
+      <div class="sigil-stat">
+        <span class="sigil-stat-value">3.8M</span>
+        <span class="sigil-stat-label">tokens</span>
+      </div>
+      <div class="sigil-stat">
+        <span class="sigil-stat-value">~207</span>
+        <span class="sigil-stat-label">hours</span>
+      </div>
+      <div class="sigil-stat">
+        <span class="sigil-stat-value">36</span>
+        <span class="sigil-stat-label">projects</span>
+      </div>
+    </div>
+
+    <!-- Activity sparkline: 30 days as ascii-style bar -->
+    <div class="sigil-spark">
+      <div class="sigil-spark-bars">
+        <span class="sigil-spark-bar" style="--h:17%" title="Feb 20: 4"></span>
+        <span class="sigil-spark-bar" style="--h:33%" title="Feb 21: 8"></span>
+        <span class="sigil-spark-bar sigil-spark-zero" title="Feb 22: 0"></span>
+        <span class="sigil-spark-bar" style="--h:100%" title="Feb 23: 24"></span>
+        <span class="sigil-spark-bar" style="--h:38%" title="Feb 24: 9"></span>
+        <span class="sigil-spark-bar" style="--h:25%" title="Feb 25: 6"></span>
+        <span class="sigil-spark-bar" style="--h:33%" title="Feb 26: 8"></span>
+        <span class="sigil-spark-bar" style="--h:42%" title="Feb 27: 10"></span>
+        <span class="sigil-spark-bar" style="--h:17%" title="Feb 28: 4"></span>
+        <span class="sigil-spark-bar" style="--h:8%" title="Mar 01: 2"></span>
+        <span class="sigil-spark-bar sigil-spark-zero" title="Mar 02: 0"></span>
+        <span class="sigil-spark-bar" style="--h:58%" title="Mar 03: 14"></span>
+        <span class="sigil-spark-bar" style="--h:67%" title="Mar 04: 16"></span>
+        <span class="sigil-spark-bar" style="--h:21%" title="Mar 05: 5"></span>
+        <span class="sigil-spark-bar" style="--h:33%" title="Mar 06: 8"></span>
+        <span class="sigil-spark-bar" style="--h:13%" title="Mar 07: 3"></span>
+        <span class="sigil-spark-bar sigil-spark-zero" title="Mar 08: 0"></span>
+        <span class="sigil-spark-bar sigil-spark-zero" title="Mar 09: 0"></span>
+        <span class="sigil-spark-bar" style="--h:42%" title="Mar 10: 10"></span>
+        <span class="sigil-spark-bar" style="--h:58%" title="Mar 11: 14"></span>
+        <span class="sigil-spark-bar" style="--h:17%" title="Mar 12: 4"></span>
+        <span class="sigil-spark-bar" style="--h:17%" title="Mar 13: 4"></span>
+        <span class="sigil-spark-bar" style="--h:13%" title="Mar 14: 3"></span>
+        <span class="sigil-spark-bar sigil-spark-zero" title="Mar 15: 0"></span>
+        <span class="sigil-spark-bar" style="--h:17%" title="Mar 16: 4"></span>
+        <span class="sigil-spark-bar" style="--h:21%" title="Mar 17: 5"></span>
+        <span class="sigil-spark-bar" style="--h:25%" title="Mar 18: 6"></span>
+        <span class="sigil-spark-bar" style="--h:13%" title="Mar 19: 3"></span>
+        <span class="sigil-spark-bar" style="--h:33%" title="Mar 20: 8"></span>
+        <span class="sigil-spark-bar" style="--h:25%" title="Mar 21: 6"></span>
+        <span class="sigil-spark-bar" style="--h:8%" title="Mar 22: 2"></span>
+      </div>
+      <div class="sigil-spark-labels">
+        <span>Feb 20</span>
+        <span>Mar 21</span>
+      </div>
+    </div>
+
+    <div class="sigil-agents">
+      <div class="sigil-agent-row">
+        <span class="sigil-agent-name">Claude Code</span>
+        <div class="sigil-agent-bar-track">
+          <div class="sigil-agent-bar-fill claude_code" style="width: 81%"></div>
+        </div>
+        <span class="sigil-agent-pct">81%</span>
+      </div>
+      <div class="sigil-agent-row">
+        <span class="sigil-agent-name">OpenClaw</span>
+        <div class="sigil-agent-bar-track">
+          <div class="sigil-agent-bar-fill openclaw" style="width: 19%"></div>
+        </div>
+        <span class="sigil-agent-pct">19%</span>
+      </div>
+    </div>
+  </div>
+
+  <!-- Numbers -->
+  <div class="sigil-numbers">
+    <p class="sigil-section-label">Numbers</p>
+    <div class="sigil-numbers-list">
+      <div class="sigil-number-row">
+        <span class="sigil-number-key">Total tokens</span>
+        <span class="sigil-number-val">1.1M in · 2.7M out</span>
+      </div>
+      <div class="sigil-number-row">
+        <span class="sigil-number-key">Avg session</span>
+        <span class="sigil-number-val">25 min · 149 turns</span>
+      </div>
+      <div class="sigil-number-row">
+        <span class="sigil-number-key">Weekday / Weekend</span>
+        <span class="sigil-number-val">80% / 20%</span>
+      </div>
+      <div class="sigil-number-row">
+        <span class="sigil-number-key">Doing / Thinking</span>
+        <span class="sigil-number-val">86% / 14%</span>
+      </div>
+      <div class="sigil-number-row">
+        <span class="sigil-number-key">One-shot rate</span>
+        <span class="sigil-number-val">7%</span>
+      </div>
+      <div class="sigil-number-row">
+        <span class="sigil-number-key">Restart rate</span>
+        <span class="sigil-number-val">11%</span>
+      </div>
+    </div>
+  </div>
+
+  <!-- Observations -->
+  <div class="sigil-observations">
+    <p class="sigil-section-label">Observations</p>
+    <ul class="sigil-observations-list">
+      <li><span class="sigil-obs-marker">&bull;</span>Claude Code handles nearly all the heavy lifting — 99% of tokens, with a median session of 24 minutes. OpenClaw sessions are far fewer but run much longer (median 5+ hours), suggesting different usage patterns: quick iterative work vs long autonomous runs.</li>
+      <li><span class="sigil-obs-marker">&bull;</span>86% of sessions involve tool usage. Most interactions are "doing" — editing files, running commands, searching code — rather than pure conversation.</li>
+      <li><span class="sigil-obs-marker">&bull;</span>Mornings are the peak across both tools. Weekdays account for 80% of all sessions, with Tuesday being the busiest day.</li>
+      <li><span class="sigil-obs-marker">&bull;</span>Feb 22 was the most active day this period with 24 sessions. Only 5 days had zero activity — roughly 83% daily coverage.</li>
+      <li><span class="sigil-obs-marker">&bull;</span>Compared to the prior 30 days, the token share has shifted dramatically toward Claude Code (from 41% to 99%), with OpenClaw dropping from 59% to 1%.</li>
+    </ul>
+  </div>
+
+  <p class="sigil-footer">Last refreshed Mar 21, 2026 · data from the last 30 days</p>
+
+</div>
+{{< /rawhtml >}}
+
+## AI Policy
 
 All the ideas, arguments and opinions on this site are mine. The thinking is mine. The mistakes are mine too.
 
@@ -20,7 +161,5 @@ I use AI tools extensively in my writing process. Editing, restructuring, catchi
 - Generating ideas or opinions
 - Writing drafts from scratch
 - Deciding what's worth writing about
-
----
 
 _Inspired by [Vicki Boykis' AI page](https://vickiboykis.com/ai/)._

--- a/content/ai.md
+++ b/content/ai.md
@@ -7,137 +7,57 @@ draft: false
 hidePagination: true
 ---
 
+A transparent look at how I use AI. I work with AI agents every day — for writing code, debugging systems, drafting prose, and thinking through problems. Rather than just talk about it, I figured I'd show the actual numbers. 
+
+This page pulls live telemetry from my agent sessions and surfaces the patterns: how often, how long, and what kind of work.
+
 {{< rawhtml >}}
-<div class="sigil-panel">
+<div class="sigil">
 
-  <p class="sigil-section-label">The Agent Log</p>
-  <p class="sigil-subtitle">A live view of everything I'm building with AI agents.</p>
+  <div class="sigil-divider sigil-row">
+    <span><strong>THE PULSE</strong></span>
+    <span class="sigil-muted">last 30 days</span>
+  </div>
 
-  <div class="sigil-pulse">
-    <div class="sigil-pulse-header">
-      <span class="sigil-pulse-label">The Pulse</span>
-      <span class="sigil-pulse-period">last 30 days</span>
+  <div class="sigil-stats">
+    <span><strong>147</strong> sessions</span>
+    <span><strong>3.8M</strong> tokens</span>
+    <span><strong>~207</strong> hours</span>
+    <span><strong>36</strong> projects</span>
+  </div>
+
+  <div class="sigil-bar-section">
+    <div class="sigil-bar-row">
+      <span class="sigil-bar-label">Claude Code</span>
+      <div class="sigil-bar-track"><div class="sigil-bar-fill" style="width:81%"></div></div>
+      <span class="sigil-bar-pct">81%</span>
     </div>
-
-    <div class="sigil-stats-row">
-      <div class="sigil-stat">
-        <span class="sigil-stat-value">147</span>
-        <span class="sigil-stat-label">sessions</span>
-      </div>
-      <div class="sigil-stat">
-        <span class="sigil-stat-value">3.8M</span>
-        <span class="sigil-stat-label">tokens</span>
-      </div>
-      <div class="sigil-stat">
-        <span class="sigil-stat-value">~207</span>
-        <span class="sigil-stat-label">hours</span>
-      </div>
-      <div class="sigil-stat">
-        <span class="sigil-stat-value">36</span>
-        <span class="sigil-stat-label">projects</span>
-      </div>
-    </div>
-
-    <!-- Activity sparkline: 30 days as ascii-style bar -->
-    <div class="sigil-spark">
-      <div class="sigil-spark-bars">
-        <span class="sigil-spark-bar" style="--h:17%" title="Feb 20: 4"></span>
-        <span class="sigil-spark-bar" style="--h:33%" title="Feb 21: 8"></span>
-        <span class="sigil-spark-bar sigil-spark-zero" title="Feb 22: 0"></span>
-        <span class="sigil-spark-bar" style="--h:100%" title="Feb 23: 24"></span>
-        <span class="sigil-spark-bar" style="--h:38%" title="Feb 24: 9"></span>
-        <span class="sigil-spark-bar" style="--h:25%" title="Feb 25: 6"></span>
-        <span class="sigil-spark-bar" style="--h:33%" title="Feb 26: 8"></span>
-        <span class="sigil-spark-bar" style="--h:42%" title="Feb 27: 10"></span>
-        <span class="sigil-spark-bar" style="--h:17%" title="Feb 28: 4"></span>
-        <span class="sigil-spark-bar" style="--h:8%" title="Mar 01: 2"></span>
-        <span class="sigil-spark-bar sigil-spark-zero" title="Mar 02: 0"></span>
-        <span class="sigil-spark-bar" style="--h:58%" title="Mar 03: 14"></span>
-        <span class="sigil-spark-bar" style="--h:67%" title="Mar 04: 16"></span>
-        <span class="sigil-spark-bar" style="--h:21%" title="Mar 05: 5"></span>
-        <span class="sigil-spark-bar" style="--h:33%" title="Mar 06: 8"></span>
-        <span class="sigil-spark-bar" style="--h:13%" title="Mar 07: 3"></span>
-        <span class="sigil-spark-bar sigil-spark-zero" title="Mar 08: 0"></span>
-        <span class="sigil-spark-bar sigil-spark-zero" title="Mar 09: 0"></span>
-        <span class="sigil-spark-bar" style="--h:42%" title="Mar 10: 10"></span>
-        <span class="sigil-spark-bar" style="--h:58%" title="Mar 11: 14"></span>
-        <span class="sigil-spark-bar" style="--h:17%" title="Mar 12: 4"></span>
-        <span class="sigil-spark-bar" style="--h:17%" title="Mar 13: 4"></span>
-        <span class="sigil-spark-bar" style="--h:13%" title="Mar 14: 3"></span>
-        <span class="sigil-spark-bar sigil-spark-zero" title="Mar 15: 0"></span>
-        <span class="sigil-spark-bar" style="--h:17%" title="Mar 16: 4"></span>
-        <span class="sigil-spark-bar" style="--h:21%" title="Mar 17: 5"></span>
-        <span class="sigil-spark-bar" style="--h:25%" title="Mar 18: 6"></span>
-        <span class="sigil-spark-bar" style="--h:13%" title="Mar 19: 3"></span>
-        <span class="sigil-spark-bar" style="--h:33%" title="Mar 20: 8"></span>
-        <span class="sigil-spark-bar" style="--h:25%" title="Mar 21: 6"></span>
-        <span class="sigil-spark-bar" style="--h:8%" title="Mar 22: 2"></span>
-      </div>
-      <div class="sigil-spark-labels">
-        <span>Feb 20</span>
-        <span>Mar 21</span>
-      </div>
-    </div>
-
-    <div class="sigil-agents">
-      <div class="sigil-agent-row">
-        <span class="sigil-agent-name">Claude Code</span>
-        <div class="sigil-agent-bar-track">
-          <div class="sigil-agent-bar-fill claude_code" style="width: 81%"></div>
-        </div>
-        <span class="sigil-agent-pct">81%</span>
-      </div>
-      <div class="sigil-agent-row">
-        <span class="sigil-agent-name">OpenClaw</span>
-        <div class="sigil-agent-bar-track">
-          <div class="sigil-agent-bar-fill openclaw" style="width: 19%"></div>
-        </div>
-        <span class="sigil-agent-pct">19%</span>
-      </div>
+    <div class="sigil-bar-row">
+      <span class="sigil-bar-label">OpenClaw</span>
+      <div class="sigil-bar-track"><div class="sigil-bar-fill" style="width:19%"></div></div>
+      <span class="sigil-bar-pct">19%</span>
     </div>
   </div>
 
-  <!-- Numbers -->
+  <div class="sigil-divider"><strong>NUMBERS</strong></div>
+
   <div class="sigil-numbers">
-    <p class="sigil-section-label">Numbers</p>
-    <div class="sigil-numbers-list">
-      <div class="sigil-number-row">
-        <span class="sigil-number-key">Total tokens</span>
-        <span class="sigil-number-val">1.1M in · 2.7M out</span>
-      </div>
-      <div class="sigil-number-row">
-        <span class="sigil-number-key">Avg session</span>
-        <span class="sigil-number-val">25 min · 149 turns</span>
-      </div>
-      <div class="sigil-number-row">
-        <span class="sigil-number-key">Weekday / Weekend</span>
-        <span class="sigil-number-val">80% / 20%</span>
-      </div>
-      <div class="sigil-number-row">
-        <span class="sigil-number-key">Doing / Thinking</span>
-        <span class="sigil-number-val">86% / 14%</span>
-      </div>
-      <div class="sigil-number-row">
-        <span class="sigil-number-key">One-shot rate</span>
-        <span class="sigil-number-val">7%</span>
-      </div>
-      <div class="sigil-number-row">
-        <span class="sigil-number-key">Restart rate</span>
-        <span class="sigil-number-val">11%</span>
-      </div>
-    </div>
+    <div class="sigil-num-row"><span>Total tokens</span><strong>1.1M in · 2.7M out</strong></div>
+    <div class="sigil-num-row"><span>Avg session</span><strong>25 min · 149 turns</strong></div>
+    <div class="sigil-num-row"><span>Weekday / Weekend</span><strong>80% / 20%</strong></div>
+    <div class="sigil-num-row"><span>Doing / Thinking</span><strong>86% / 14%</strong></div>
+    <div class="sigil-num-row"><span>One-shot rate</span><strong>7%</strong></div>
+    <div class="sigil-num-row"><span>Restart rate</span><strong>11%</strong></div>
   </div>
 
-  <!-- Observations -->
-  <div class="sigil-observations">
-    <p class="sigil-section-label">Observations</p>
-    <ul class="sigil-observations-list">
-      <li><span class="sigil-obs-marker">&bull;</span>Claude Code handles nearly all the heavy lifting — 99% of tokens, with a median session of 24 minutes. OpenClaw sessions are far fewer but run much longer (median 5+ hours), suggesting different usage patterns: quick iterative work vs long autonomous runs.</li>
-      <li><span class="sigil-obs-marker">&bull;</span>86% of sessions involve tool usage. Most interactions are "doing" — editing files, running commands, searching code — rather than pure conversation.</li>
-      <li><span class="sigil-obs-marker">&bull;</span>Mornings are the peak across both tools. Weekdays account for 80% of all sessions, with Tuesday being the busiest day.</li>
-      <li><span class="sigil-obs-marker">&bull;</span>Feb 22 was the most active day this period with 24 sessions. Only 5 days had zero activity — roughly 83% daily coverage.</li>
-      <li><span class="sigil-obs-marker">&bull;</span>Compared to the prior 30 days, the token share has shifted dramatically toward Claude Code (from 41% to 99%), with OpenClaw dropping from 59% to 1%.</li>
-    </ul>
+  <div class="sigil-divider"><strong>OBSERVATIONS</strong></div>
+
+  <div class="sigil-obs">
+    <p>· Claude Code handles nearly all the heavy lifting — 99% of tokens, with a median session of 24 minutes. OpenClaw sessions are fewer but run much longer (median 5+ hours): quick iterative work vs long autonomous runs.</p>
+    <p>· 86% of sessions involve tool usage. Most interactions are "doing" — editing files, running commands, searching code — rather than pure conversation.</p>
+    <p>· Mornings are the peak across both tools. Weekdays account for 80% of all sessions, with Tuesday being the busiest day.</p>
+    <p>· Feb 22 was the most active day this period with 24 sessions. Only 5 days had zero activity — roughly 83% daily coverage.</p>
+    <p>· Compared to the prior 30 days, token share shifted dramatically toward Claude Code (41% → 99%), with OpenClaw dropping from 59% to 1%.</p>
   </div>
 
   <p class="sigil-footer">Last refreshed Mar 21, 2026 · data from the last 30 days</p>


### PR DESCRIPTION
## Summary
- Adds a live telemetry panel to the /ai page showing AI agent usage stats from the last 30 days
- Pure monospace terminal aesthetic: session counts, token totals, hours, project count, agent breakdown bars, key metrics, and observations
- Data sourced from ClickHouse session logs (147 sessions, 3.8M tokens, ~207 hrs across 36 projects)
- AI policy section moved to the bottom of the page

## Test plan
- [ ] Verify the page renders correctly at https://junaid.foo/ai after deploy
- [ ] Check responsive layout on mobile
- [ ] Confirm agent bars and numbers section display properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)