### PR TITLE
chore: refresh AI telemetry stats

### DIFF
--- a/content/ai.md
+++ b/content/ai.md
@@ -20,47 +20,47 @@ This page pulls live telemetry from my agent sessions and surfaces the patterns:
   </div>
 
   <div class="sigil-stats">
-    <span><strong>147</strong> sessions</span>
-    <span><strong>3.8M</strong> tokens</span>
-    <span><strong>~207</strong> hours</span>
-    <span><strong>36</strong> projects</span>
+    <span><strong>164</strong> sessions</span>
+    <span><strong>3.9M</strong> tokens</span>
+    <span><strong>~214</strong> hours</span>
+    <span><strong>38</strong> projects</span>
   </div>
 
   <div class="sigil-bar-section">
     <div class="sigil-bar-row">
       <span class="sigil-bar-label">Claude Code</span>
-      <div class="sigil-bar-track"><div class="sigil-bar-fill" style="width:81%"></div></div>
-      <span class="sigil-bar-pct">81%</span>
+      <div class="sigil-bar-track"><div class="sigil-bar-fill" style="width:83%"></div></div>
+      <span class="sigil-bar-pct">83%</span>
     </div>
     <div class="sigil-bar-row">
       <span class="sigil-bar-label">OpenClaw</span>
-      <div class="sigil-bar-track"><div class="sigil-bar-fill" style="width:19%"></div></div>
-      <span class="sigil-bar-pct">19%</span>
+      <div class="sigil-bar-track"><div class="sigil-bar-fill" style="width:17%"></div></div>
+      <span class="sigil-bar-pct">17%</span>
     </div>
   </div>
 
   <div class="sigil-divider"><strong>NUMBERS</strong></div>
 
   <div class="sigil-numbers">
-    <div class="sigil-num-row"><span>Total tokens</span><strong>1.1M in · 2.7M out</strong></div>
-    <div class="sigil-num-row"><span>Avg session</span><strong>25 min · 149 turns</strong></div>
-    <div class="sigil-num-row"><span>Weekday / Weekend</span><strong>80% / 20%</strong></div>
-    <div class="sigil-num-row"><span>Doing / Thinking</span><strong>86% / 14%</strong></div>
-    <div class="sigil-num-row"><span>One-shot rate</span><strong>7%</strong></div>
+    <div class="sigil-num-row"><span>Total tokens</span><strong>1.1M in · 2.8M out</strong></div>
+    <div class="sigil-num-row"><span>Avg session</span><strong>16 min · 148 turns</strong></div>
+    <div class="sigil-num-row"><span>Weekday / Weekend</span><strong>83% / 17%</strong></div>
+    <div class="sigil-num-row"><span>Doing / Thinking</span><strong>84% / 16%</strong></div>
+    <div class="sigil-num-row"><span>One-shot rate</span><strong>12%</strong></div>
     <div class="sigil-num-row"><span>Restart rate</span><strong>11%</strong></div>
   </div>
 
   <div class="sigil-divider"><strong>OBSERVATIONS</strong></div>
 
   <div class="sigil-obs">
-    <p>· Claude Code handles nearly all the heavy lifting — 99% of tokens, with a median session of 24 minutes. OpenClaw sessions are fewer but run much longer (median 5+ hours): quick iterative work vs long autonomous runs.</p>
-    <p>· 86% of sessions involve tool usage. Most interactions are "doing" — editing files, running commands, searching code — rather than pure conversation.</p>
-    <p>· Mornings are the peak across both tools. Weekdays account for 80% of all sessions, with Tuesday being the busiest day.</p>
-    <p>· Feb 22 was the most active day this period with 24 sessions. Only 5 days had zero activity — roughly 83% daily coverage.</p>
-    <p>· Compared to the prior 30 days, token share shifted dramatically toward Claude Code (41% → 99%), with OpenClaw dropping from 59% to 1%.</p>
+    <p>· Claude Code dominates with 99% of all tokens across 83% of sessions. OpenClaw sessions are fewer but run far longer — median 3+ hours vs 15 minutes for Claude Code. Two very different modes: interactive coding vs autonomous runs.</p>
+    <p>· 84% of sessions involve tool usage. Most interactions are "doing" — editing files, running commands, searching code — rather than pure conversation.</p>
+    <p>· Mornings are the peak across both tools. Weekdays account for 83% of all sessions, with Thursday being the busiest day.</p>
+    <p>· Sessions nearly tripled compared to the prior 30 days (57 → 164). Feb 22 was the most active day with 24 sessions. Only 5 days had zero activity — 83% daily coverage.</p>
+    <p>· Claude Code's token share grew from 37% to 99% compared to the prior period, while OpenClaw dropped from 63% to 1% — a clear shift from autonomous runs to interactive coding.</p>
   </div>
 
-  <p class="sigil-footer">Last refreshed Mar 21, 2026 · data from the last 30 days</p>
+  <p class="sigil-footer">Last refreshed Mar 21, 2026 · data from Feb 19 – Mar 21, 2026</p>
 
 </div>
 {{< /rawhtml >}}


### PR DESCRIPTION
## Summary
- Refreshed /ai page telemetry from ClickHouse (Feb 19 – Mar 21, 2026)
- Updated all stats: 164 sessions, 3.9M tokens, ~214 hours, 38 projects
- Updated observations to reflect session tripling and Claude Code dominance shift

## Test plan
- [ ] Verify /ai page renders correctly with `hugo server`
- [ ] Check numbers match ClickHouse source data

🤖 Generated with [Claude Code](https://claude.com/claude-code)