### PR TITLE
feat: add /projects page

### DIFF
--- a/content/projects.md
+++ b/content/projects.md
@@ -1,0 +1,74 @@
+---
+title: "Projects"
+toc: false
+readTime: false
+math: false
+draft: false
+hidePagination: true
+---
+
+A selection of things I've built over the years. Most of these are open source and live on [GitHub](https://github.com/junaidrahim).
+
+## Tools & CLIs
+
+- [**sigil**](https://github.com/junaidrahim/sigil) — Collect, store, and analyse your AI usage data from Claude Code and Codex CLI. Supports local parquet, Iceberg, and ClickHouse backends. Powers the telemetry on my [/ai](/ai) page. `Python`
+
+- [**locate-route**](https://github.com/junaidrahim/locate-route) — Command line tool to grab the geographical location of hops from traceroute. `C++`
+
+- [**yaml-config-lint**](https://github.com/junaidrahim/yaml-config-lint) — Lint multiline JSON config embedded in YAML files. `TypeScript`
+
+- [**dogetick**](https://github.com/junaidrahim/dogetick) — An INR-based command line ticker for $DOGE. `TypeScript`
+
+- [**autotyper**](https://github.com/junaidrahim/autotyper) — A simple command line tool to write the contents of a file to the cursor after a delay. `Python`
+
+- [**code-to-pdf**](https://github.com/junaidrahim/code-to-pdf) — Generate an assignment submission PDF from a bunch of program files. `JavaScript`
+
+- [**program-homework-solver**](https://github.com/junaidrahim/program-homework-solver) — Input a few integers of a series and it returns the source code to output that series till the nth term. Uses Lagrange polynomial interpolation. `C++`
+
+## AI & Agents
+
+- [**weatherunion-mcp**](https://github.com/junaidrahim/weatherunion-mcp) — MCP server for the Weather Union API. Access real-time weather conditions and air quality data for Indian cities and localities. `Python`
+
+- [**tbpn**](https://github.com/junaidrahim/tbpn) — A skill for your agent to give you a nice newspaper with all the highlights from the latest on TBPN. `HTML`
+
+- [**skills**](https://github.com/junaidrahim/skills) — Personal skills stack used by my agents.
+
+## Data & Infrastructure
+
+- [**duckdb-with-argo-wf**](https://github.com/junaidrahim/duckdb-with-argo-wf) — Reference implementation for running analytical data pipelines with DuckDB on Argo Workflows. Companion code for my [DuckCon #5 talk](/talks/duckdb-scalable-pipelines/). `Python`
+
+- [**agriIOT-cloud**](https://github.com/junaidrahim/agriIOT-cloud) — Cloud component of an agricultural IoT system. `Jupyter Notebook`
+
+## Web
+
+- [**webrtc-session**](https://github.com/junaidrahim/webrtc-session) — WebRTC session management. `JavaScript`
+
+- [**DownloadGator**](https://github.com/junaidrahim/DownloadGator) — Enter a link, downloads the file on the server. Built with Flask and paired with a Telegram bot. `Python`
+
+- [**javascriptquizgame**](https://github.com/junaidrahim/javascriptquizgame) — A game built on top of the famous JavaScript Questions by Lydia Hallie. `JavaScript`
+
+- [**KBC-webapp**](https://github.com/junaidrahim/KBC-webapp) + [**KBC-Quiz-App**](https://github.com/junaidrahim/KBC-Quiz-App) — A webapp paired with an Android app to conduct a group quiz game. `Python` `Java`
+
+- [**labprogramsgenerator**](https://github.com/junaidrahim/labprogramsgenerator) — Simple website to download C lab programs done in KIIT first year. `HTML`
+
+## Research & Writing
+
+- [**compression-review-article**](https://github.com/junaidrahim/compression-review-article) — A review article on lossless data compression algorithms. `LaTeX`
+
+- [**ml-derivations**](https://github.com/junaidrahim/ml-derivations) — Mathematical derivations of ML algorithms. `LaTeX`
+
+## Dotfiles & Misc
+
+- [**website**](https://github.com/junaidrahim/website) — Source for this website. Built with Hugo. `CSS`
+
+- [**nvim.lua**](https://github.com/junaidrahim/nvim.lua) — My Neovim setup. `Lua`
+
+- [**conky-clock**](https://github.com/junaidrahim/conky-clock) — A simple conky clock for Linux desktops. `Shell`
+
+- [**DES**](https://github.com/junaidrahim/DES) — Implementation of the DES encryption algorithm. `C++`
+
+- [**arithmetic-coding**](https://github.com/junaidrahim/arithmetic-coding) — Arithmetic coding implementation. `C++`
+
+- [**tictactoe**](https://github.com/junaidrahim/tictactoe) — The classic tic tac toe game written in every language I could possibly write. `C++` `Java` `Python`
+
+- [**kiitwifi-speedtest**](https://github.com/junaidrahim/kiitwifi-speedtest) — A 24 hour continuous speedtest of KIIT wifi. `Jupyter Notebook`

--- a/hugo.toml
+++ b/hugo.toml
@@ -90,6 +90,10 @@ name = "talks"
 url = "/talks"
 
 [[params.menu]]
+name = "projects"
+url = "/projects"
+
+[[params.menu]]
 name = "about"
 url = "/about"
 


### PR DESCRIPTION
## Summary
- Adds a new `/projects` page showcasing curated GitHub repos (forks, archived, and work-related LookML repos filtered out)
- Projects organized into thematic sections: Tools & CLIs, AI & Agents, Data & Infrastructure, Web, Research & Writing, Dotfiles & Misc
- Adds navigation menu entry between "talks" and "about"

## Test plan
- [ ] Verify `/projects` page renders correctly with `hugo server`
- [ ] Check all GitHub repo links are valid
- [ ] Confirm navigation menu shows "projects" in the right position
- [ ] Test mobile responsiveness

🤖 Generated with [Claude Code](https://claude.com/claude-code)