### PR TITLE
feat: add year tags to projects page

### DIFF
--- a/content/projects.md
+++ b/content/projects.md
@@ -11,64 +11,64 @@ A selection of things I've built over the years. Most of these are open source a
 
 ## Tools & CLIs
 
-- [**sigil**](https://github.com/junaidrahim/sigil) — Collect, store, and analyse your AI usage data from Claude Code and Codex CLI. Supports local parquet, Iceberg, and ClickHouse backends. Powers the telemetry on my [/ai](/ai) page. `Python`
+- [**sigil**](https://github.com/junaidrahim/sigil) — Collect, store, and analyse your AI usage data from Claude Code and Codex CLI. Supports local parquet, Iceberg, and ClickHouse backends. Powers the telemetry on my [/ai](/ai) page. `Python` `2026`
 
-- [**locate-route**](https://github.com/junaidrahim/locate-route) — Command line tool to grab the geographical location of hops from traceroute. `C++`
+- [**yaml-config-lint**](https://github.com/junaidrahim/yaml-config-lint) — Lint multiline JSON config embedded in YAML files. `TypeScript` `2021`
 
-- [**yaml-config-lint**](https://github.com/junaidrahim/yaml-config-lint) — Lint multiline JSON config embedded in YAML files. `TypeScript`
+- [**locate-route**](https://github.com/junaidrahim/locate-route) — Command line tool to grab the geographical location of hops from traceroute. `C++` `2021`
 
-- [**dogetick**](https://github.com/junaidrahim/dogetick) — An INR-based command line ticker for $DOGE. `TypeScript`
+- [**dogetick**](https://github.com/junaidrahim/dogetick) — An INR-based command line ticker for $DOGE. `TypeScript` `2021`
 
-- [**autotyper**](https://github.com/junaidrahim/autotyper) — A simple command line tool to write the contents of a file to the cursor after a delay. `Python`
+- [**code-to-pdf**](https://github.com/junaidrahim/code-to-pdf) — Generate an assignment submission PDF from a bunch of program files. `JavaScript` `2021`
 
-- [**code-to-pdf**](https://github.com/junaidrahim/code-to-pdf) — Generate an assignment submission PDF from a bunch of program files. `JavaScript`
+- [**autotyper**](https://github.com/junaidrahim/autotyper) — A simple command line tool to write the contents of a file to the cursor after a delay. `Python` `2020`
 
-- [**program-homework-solver**](https://github.com/junaidrahim/program-homework-solver) — Input a few integers of a series and it returns the source code to output that series till the nth term. Uses Lagrange polynomial interpolation. `C++`
+- [**program-homework-solver**](https://github.com/junaidrahim/program-homework-solver) — Input a few integers of a series and it returns the source code to output that series till the nth term. Uses Lagrange polynomial interpolation. `C++` `2018`
 
 ## AI & Agents
 
-- [**weatherunion-mcp**](https://github.com/junaidrahim/weatherunion-mcp) — MCP server for the Weather Union API. Access real-time weather conditions and air quality data for Indian cities and localities. `Python`
+- [**tbpn**](https://github.com/junaidrahim/tbpn) — A skill for your agent to give you a nice newspaper with all the highlights from the latest on TBPN. `HTML` `2026`
 
-- [**tbpn**](https://github.com/junaidrahim/tbpn) — A skill for your agent to give you a nice newspaper with all the highlights from the latest on TBPN. `HTML`
+- [**skills**](https://github.com/junaidrahim/skills) — Personal skills stack used by my agents. `2026`
 
-- [**skills**](https://github.com/junaidrahim/skills) — Personal skills stack used by my agents.
+- [**weatherunion-mcp**](https://github.com/junaidrahim/weatherunion-mcp) — MCP server for the Weather Union API. Access real-time weather conditions and air quality data for Indian cities and localities. `Python` `2025`
 
 ## Data & Infrastructure
 
-- [**duckdb-with-argo-wf**](https://github.com/junaidrahim/duckdb-with-argo-wf) — Reference implementation for running analytical data pipelines with DuckDB on Argo Workflows. Companion code for my [DuckCon #5 talk](/talks/duckdb-scalable-pipelines/). `Python`
+- [**duckdb-with-argo-wf**](https://github.com/junaidrahim/duckdb-with-argo-wf) — Reference implementation for running analytical data pipelines with DuckDB on Argo Workflows. Companion code for my [DuckCon #5 talk](/talks/duckdb-scalable-pipelines/). `Python` `2024`
 
-- [**agriIOT-cloud**](https://github.com/junaidrahim/agriIOT-cloud) — Cloud component of an agricultural IoT system. `Jupyter Notebook`
+- [**agriIOT-cloud**](https://github.com/junaidrahim/agriIOT-cloud) — Cloud component of an agricultural IoT system. `Jupyter Notebook` `2020`
 
 ## Web
 
-- [**webrtc-session**](https://github.com/junaidrahim/webrtc-session) — WebRTC session management. `JavaScript`
+- [**webrtc-session**](https://github.com/junaidrahim/webrtc-session) — WebRTC session management. `JavaScript` `2021`
 
-- [**DownloadGator**](https://github.com/junaidrahim/DownloadGator) — Enter a link, downloads the file on the server. Built with Flask and paired with a Telegram bot. `Python`
+- [**javascriptquizgame**](https://github.com/junaidrahim/javascriptquizgame) — A game built on top of the famous JavaScript Questions by Lydia Hallie. `JavaScript` `2019`
 
-- [**javascriptquizgame**](https://github.com/junaidrahim/javascriptquizgame) — A game built on top of the famous JavaScript Questions by Lydia Hallie. `JavaScript`
+- [**labprogramsgenerator**](https://github.com/junaidrahim/labprogramsgenerator) — Simple website to download C lab programs done in KIIT first year. `HTML` `2019`
 
-- [**KBC-webapp**](https://github.com/junaidrahim/KBC-webapp) + [**KBC-Quiz-App**](https://github.com/junaidrahim/KBC-Quiz-App) — A webapp paired with an Android app to conduct a group quiz game. `Python` `Java`
+- [**KBC-webapp**](https://github.com/junaidrahim/KBC-webapp) + [**KBC-Quiz-App**](https://github.com/junaidrahim/KBC-Quiz-App) — A webapp paired with an Android app to conduct a group quiz game. `Python` `Java` `2018`
 
-- [**labprogramsgenerator**](https://github.com/junaidrahim/labprogramsgenerator) — Simple website to download C lab programs done in KIIT first year. `HTML`
+- [**DownloadGator**](https://github.com/junaidrahim/DownloadGator) — Enter a link, downloads the file on the server. Built with Flask and paired with a Telegram bot. `Python` `2018`
 
 ## Research & Writing
 
-- [**compression-review-article**](https://github.com/junaidrahim/compression-review-article) — A review article on lossless data compression algorithms. `LaTeX`
+- [**compression-review-article**](https://github.com/junaidrahim/compression-review-article) — A review article on lossless data compression algorithms. `LaTeX` `2020`
 
-- [**ml-derivations**](https://github.com/junaidrahim/ml-derivations) — Mathematical derivations of ML algorithms. `LaTeX`
+- [**ml-derivations**](https://github.com/junaidrahim/ml-derivations) — Mathematical derivations of ML algorithms. `LaTeX` `2020`
 
 ## Dotfiles & Misc
 
-- [**website**](https://github.com/junaidrahim/website) — Source for this website. Built with Hugo. `CSS`
+- [**website**](https://github.com/junaidrahim/website) — Source for this website. Built with Hugo. `CSS` `2024`
 
-- [**nvim.lua**](https://github.com/junaidrahim/nvim.lua) — My Neovim setup. `Lua`
+- [**nvim.lua**](https://github.com/junaidrahim/nvim.lua) — My Neovim setup. `Lua` `2023`
 
-- [**conky-clock**](https://github.com/junaidrahim/conky-clock) — A simple conky clock for Linux desktops. `Shell`
+- [**DES**](https://github.com/junaidrahim/DES) — Implementation of the DES encryption algorithm. `C++` `2021`
 
-- [**DES**](https://github.com/junaidrahim/DES) — Implementation of the DES encryption algorithm. `C++`
+- [**arithmetic-coding**](https://github.com/junaidrahim/arithmetic-coding) — Arithmetic coding implementation. `C++` `2021`
 
-- [**arithmetic-coding**](https://github.com/junaidrahim/arithmetic-coding) — Arithmetic coding implementation. `C++`
+- [**kiitwifi-speedtest**](https://github.com/junaidrahim/kiitwifi-speedtest) — A 24 hour continuous speedtest of KIIT wifi. `Jupyter Notebook` `2019`
 
-- [**tictactoe**](https://github.com/junaidrahim/tictactoe) — The classic tic tac toe game written in every language I could possibly write. `C++` `Java` `Python`
+- [**conky-clock**](https://github.com/junaidrahim/conky-clock) — A simple conky clock for Linux desktops. `Shell` `2018`
 
-- [**kiitwifi-speedtest**](https://github.com/junaidrahim/kiitwifi-speedtest) — A 24 hour continuous speedtest of KIIT wifi. `Jupyter Notebook`
+- [**tictactoe**](https://github.com/junaidrahim/tictactoe) — The classic tic tac toe game written in every language I could possibly write. `C++` `Java` `Python` `2018`


### PR DESCRIPTION
## Summary
- Adds year (from GitHub repo creation date) to each project as a backtick tag
- Sorts projects within each section in reverse chronological order (newest first)

## Test plan
- [ ] Verify year tags render correctly on `/projects`
- [ ] Confirm sort order is newest-first within each section

🤖 Generated with [Claude Code](https://claude.com/claude-code)