### PR TITLE
chore: update employer from Atlan to dbt Labs

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -4,17 +4,17 @@ title: "About"
 
 👋🏻 Hi, I’m Junaid.
 
-I'm a systems engineer based in Bengaluru, currently helping build the future of agentic data collaboration at [Atlan](https://atlan.com).
+I'm a senior software engineer based in Bengaluru, currently working at [dbt Labs](https://www.getdbt.com).
 
 My work sits at the intersection of distributed systems, developer experience, and AI-native engineering.
 
 ## Work
 
-I wear multiple hats at Atlan. My work spans the following domains:
+Previously at [Atlan](https://atlan.com), I wore multiple hats across the following domains:
 
 **Platform Engineering**
 
-My primary focus right now is on the [Atlan App Framework](https://github.com/atlanhq/application-sdk) that enables our customers, forward-deployed and internal engineering teams to build on top of the Atlan platform faster and better.
+I worked on the [Atlan App Framework](https://github.com/atlanhq/application-sdk) that enables customers, forward-deployed and internal engineering teams to build on top of the Atlan platform faster and better.
 
 **Data Engineering**
 

--- a/hugo.toml
+++ b/hugo.toml
@@ -20,7 +20,7 @@ homeIntroTitle = 'Hello ☕️'
 homeIntroContent = """
 Just another [hacker](https://phrack.org/issues/7/3).
 
-I'm currently working as a systems engineer at [Atlan](https://atlan.com) building the future of agentic data collaboration. 
+I'm currently working as a senior software engineer at [dbt Labs](https://www.getdbt.com).
 
 Living in Bengaluru, India.
 


### PR DESCRIPTION
## Summary
- Update home intro (`hugo.toml`) and about page (`content/about.md`) to reflect the move from Atlan to dbt Labs
- Reframe Atlan-specific work (Atlan App Framework, multiple-hats line) as past employment
- Blog posts and talks left untouched (out of scope)

## Test plan
- [ ] `hugo server` renders home page with updated intro
- [ ] `/about` renders with dbt Labs as current employer and Atlan as previous
- [ ] No remaining present-tense "at Atlan" mentions on home or about page

🤖 Generated with [Claude Code](https://claude.com/claude-code)