### PR TITLE
feat: add 'An Ontology for your Second Brain' post

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,11 @@
+{
+  "overrides": [
+    {
+      "files": ["*.md", "*.markdown"],
+      "options": {
+        "printWidth": 120,
+        "proseWrap": "always"
+      }
+    }
+  ]
+}

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -1,0 +1,23 @@
+/* Tables: gray borders on all cells, overriding the theme's outer-and-row-only borders */
+:root {
+  --table-border-light: rgb(176, 176, 176);
+  --table-border-dark: rgb(96, 96, 96);
+  --table-border: light-dark(var(--table-border-light), var(--table-border-dark));
+}
+
+table {
+  /* the reset makes tables display:block, so the table's own border can't
+     collapse with cell borders — let the outer cells draw the edge instead */
+  border: none;
+  border-radius: 0;
+  border-collapse: collapse;
+}
+
+th,
+td {
+  border: 1px solid var(--table-border);
+}
+
+tbody tr {
+  border-top: 1px solid var(--table-border);
+}

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,3 +1,30 @@
+:root {
+  color-scheme: light dark;
+
+  --content-primary: light-dark(
+    var(--content-primary-light),
+    var(--content-primary-dark)
+  );
+  --content-secondary: light-dark(
+    var(--content-secondary-light),
+    var(--content-secondary-dark)
+  );
+  --background: light-dark(var(--background-light), var(--background-dark));
+  --code-background: light-dark(
+    var(--code-background-light),
+    var(--code-background-dark)
+  );
+  --code-border: light-dark(var(--code-border-light), var(--code-border-dark));
+}
+
+.light {
+  color-scheme: light;
+}
+
+.dark {
+  color-scheme: dark;
+}
+
 html {
   scroll-behavior: smooth;
 }

--- a/content/about.md
+++ b/content/about.md
@@ -6,7 +6,7 @@ title: "About"
 
 I'm a senior software engineer based in Bengaluru, currently working at [dbt Labs](https://www.getdbt.com).
 
-Previously, I was an early engineer at [Atlan](https://atlan.com/). 
+Previously, I was an early engineer at [Atlan](https://atlan.com/).
 
 My work sits at the intersection of distributed systems, developer experience, and AI-native engineering.
 

--- a/content/drafts/infinite-representations.md
+++ b/content/drafts/infinite-representations.md
@@ -10,41 +10,39 @@ math: true
 draft: false
 ---
 
-I love reading Andy's blogs because of the way he deeply thinks about the process of learning and how technology aids it. He has written about 
+I love reading Andy's blogs because of the way he deeply thinks about the process of learning and how technology aids it. He has written about
 how we should re-think the textbook all together as a learning instrument amongst many other things. As someone who spends a lot of time
 thinking about how I like to learn things, his writings have offered a lot of perspective on how one should think about their learning practises.
 
 What's really exciting today is how much you can use AI to learn new things, and that unlocks this is AI's ability to produce infinite representations
 of the same idea.
 
-
 Humans usually have depended a lot on subject matter experts to explain things in various formats so that they can absorb them, it got easier with the internet.
 You could learn about the same topic from different people. You can watch a lecture by a professor on youtube or read the blogs or reddit comments from practitioners
 talking about the same from a completely different POV.
 
-With AI, it becomes even easier, you can create almost infinite representations of the same piece of knowledege. 
+With AI, it becomes even easier, you can create almost infinite representations of the same piece of knowledege.
 
 A lot of these thoughts bubbled up when I was trying to write some cron agents in my hermes setup to create curriculums for me to learn topics I am interested in.
 
 I am a very prose-friendly learner, I prefer reading things to make sense of them. If you give me a bunch of pages that explain something like peeling layers of
 an onion, I am able to grasp things faster, if those pages have diagrams then it's great, I was trying to setup flows where my agent would figure out this curriculum
-which is shaped very much to my ways of capturing knowledge, that'd be great. 
+which is shaped very much to my ways of capturing knowledge, that'd be great.
 
 NotebookLM is very good at this, you can give it papers and it can turn it into a nice deck of slides that can warm you up in a way that reading the paper won't feel
-like walking into a dark tunnel. 
+like walking into a dark tunnel.
 
 I am very interested in turning this into a product that I can use to elaborate a desire to learn something and the agent goes out to build a curriculum, come up with
 exercises, block time on my calendar and keep track of my progress.
 
 And this is what I feel is the actual end goal of all PKM systems, these were supposed to exist for two reasons -- to learn so you can produce more. Whatever more is, more blogs
-better work, more creative output. 
+better work, more creative output.
 
 What's the point of having complex looking knowledge graphs in obsidian if you are not using all that knowledege to do whatever you set out to do.
 
-
 One of the things I love using AI for is to explain things in multiple formats or dimensions, if you've used NotebookLM you understand this well.
 
-It's very easy to distill any idea or explanation into a desired difficulty level 
+It's very easy to distill any idea or explanation into a desired difficulty level
 
 Which makes me kinda optimistic about AI in PKM.
 
@@ -52,7 +50,6 @@ Ideas can be sliced and diced into various formats
 
 Edward Tufte's book on the visual display of quantitative information. AI is adding so much multimodality to represent any piece of knowledge or information.
 
-the speed at which ai can produce multiple representations of anything makes a very interesting case of products in the writing and education space. 
-
+the speed at which ai can produce multiple representations of anything makes a very interesting case of products in the writing and education space.
 
 Being able to visualise something a

--- a/content/posts/markdown-ontologies.md
+++ b/content/posts/markdown-ontologies.md
@@ -1,0 +1,198 @@
+---
+title: "smolbren: Ontology first search over Markdown"
+date: "2026-07-03T13:12:58+05:30"
+summary: ""
+description: "How to manage a vault of markdown notes in an ontology first fashion."
+toc: true
+readTime: true
+autonumber: false
+math: true
+draft: false
+---
+
+> **tldr**; this about a tool I wrote called [smolbren](http://github.com/junaidrahim/smolbren) to make ontology driven
+> agentic search faster and token-efficient over my obsidian vault (~13k notes).
+
+If you've setup a LLM driven knowledge base[^1], one of the very first things you ask your agent to do is to go over
+your vault and come up with some sort of a schema, a set of types for the documents that go into your vault.
+
+You might write it as a skill or just add it as a prompt that whenever you are processing a bunch of text, try to figure
+out what type should be attached to this note.
+
+Types would be things like `recipe`, `idea`, `algorithm`, `essay`, `person`, `company`, `device`, `book` etc,
+
+This is what enables your agent to make organising decisions, and that was the essence of Karpathy's post, to hand over
+most of the admin work of maintaing a knowledge base to an agent by writing down these principles in skills or prompts.
+
+After you have types in your vault, and you are using something like Obsidian that allows wikilinks between notes, you
+can also define how edges should be created between the notes.
+
+What you just did is define an [ontology](<https://en.wikipedia.org/wiki/Ontology_(information_science)>) for your
+vault, and agents love ontologies, it allows them to independently reason how to organise ingested documents.
+
+You can also add instructions on how to expand this ontology if new notes are ingested that don't squarely fit in a
+given type or relationship.
+
+I also did the same. This is what a note in my vault looks like now.
+
+```markdown
+---
+type: book
+status: reading
+started: 2026-06-01
+author: "[[people/ursula-k-le-guin]]"
+themes: ["[[topics/anarchism]]", "[[topics/utopia]]"]
+related: ["[[books/the-left-hand-of-darkness]]"]
+---
+
+# The Dispossessed
+
+An ambiguous utopia: two worlds, one wall, and the physicist who tries to unbuild it. ...
+```
+
+I used markdown frontmatter to encode all the things that are required for the ontology, the `type` key denotes the type
+of the note and relationships are arbitrary keys with list of wikilinks.
+
+This is what the graph would for the note and it's linked notes would look like.
+
+```mermaid
+graph LR
+    dispossessed["books/the-dispossessed (book)"]
+    leguin["people/ursula-k-le-guin (person)"]
+    anarchism["topics/anarchism (topic)"]
+    utopia["topics/utopia (topic)"]
+    lefthand["books/the-left-hand-of-darkness (book)"]
+
+    dispossessed -->|"author"| leguin
+    dispossessed -->|"themes"| anarchism
+    dispossessed -->|"themes"| utopia
+    dispossessed -->|"related"| lefthand
+```
+
+And zooming out from the note, this is what the ontology itself looks like -- the types and the relationships allowed
+between them.
+
+```mermaid
+graph LR
+    book["book"]
+    person["person"]
+    topic["topic"]
+
+    book -->|"author"| person
+    book -->|"themes"| topic
+    book -->|"related"| book
+```
+
+I also clip a lot of web articles using the obsidian web clipper and you frequently ask agents to research a topic and
+keep a few markdown files ready for me to review, naturally my vault grew by ~6x in terms of number of notes.
+
+## Introducing `smolbren`
+
+All this agent generated markdown volume was wasting a lot of tokens while doing searches, I often found higher latency
+for questions which involved querying multiple types and relationships.
+
+So I decided to solve this problem by introducing a sort of ontology-aware search layer. Something that would run
+locally and fast and that could crawl the frontmatter and the markdown content and build an index that would help me do
+graph queries (cypher), along with BM25 and vector search (using local models).
+
+I named it `smolbren`, because it's truly a very small brain that you can add to your agent setups and let the agent use
+it in specific ways to make search more token efficient.
+
+`smolbren` is written in rust using lancedb for storage and lance-graph for implementing the Cypher query language, I
+used [embeddinggemma-300M-Q8_0](https://huggingface.co/google/embeddinggemma-300m-qat-q8_0-unquantized) for vector
+embeddings.
+
+You can read the docs at [smolbren.com](https://smolbren.com/). Or you can give the following prompt to your agent
+
+```markdown
+Read the docs at https://smolbren.com, mainly the installation and quickstart pages,
+and set up smolbren on this machine for my markdown vault.
+
+1. Check the prerequisites first -- a Rust toolchain (1.85+) and protoc on PATH.
+   Install whatever is missing (rustup for Rust, `brew install protobuf` on macOS
+   or `apt-get install protobuf-compiler` on Linux).
+2. Install it with `cargo install smolbren` and verify with `smolbren --version`.
+3. My vault lives at <path-to-your-vault>. Register it with
+   `smolbren vault add personal <path>` and run `smolbren index`.
+4. Show me the ontology it discovered -- run `smolbren types` and `smolbren edges`
+   and summarize what note types and relationships exist in my vault.
+5. Sanity check the search: run one `smolbren search` and one `smolbren query`
+   (Cypher) that are relevant to my notes and show me the raw output.
+
+If anything fails, read the relevant page on smolbren.com before retrying.
+```
+
+This is ideal for people like me who don't want to go all-in on a setup like
+[gbrain](https://github.com/garrytan/gbrain) which takes all of the control away from you. If you want to still play
+around with your own way of doing CRON jobs and setting up your dreaming sequence, you can ask your agent to use
+`smolbren` in a variety of different ways.
+
+### Performance
+
+- **Question: "How many projects have a blog linked to them?"**
+- Test Setup: 5,000-note vault, 15,000 links.
+
+| Approach                                                                               | Agent ingests        | Turns |
+| -------------------------------------------------------------------------------------- | -------------------- | ----- |
+| `smolbren query "MATCH (b:blog)-[:mentions]->(p:project) RETURN count(DISTINCT p.id)"` | **37 bytes**         | 1     |
+| grep, naive (list blogs → pull their `mentions:` lines → count in-context)             | 610KB (~150k tokens) | 3+    |
+
+## In Conclusion
+
+My hermes agent now uses smolbren to rip through my obsidian vault and make sure that things are as per the ontology,
+and if needed it grows the ontology on it's own.
+
+This is also a very different approach to doing the second brain thing, I imagine this whole thing as a spectrum, where
+on one hand you could fully analog raw dog it and write everything on yourself and manually store things in specific
+files.
+
+You could also try a bunch of other second brain solutions which I feel deeply undermine the highest signal you can give
+to your setup which is your own long form writing. There is no point in having the second brain index literally
+everything you see on your screen and all the notifications or emails or meetings notes you get. And then ask it dumb
+questions like "oh tell me everything I've read about this topic".
+
+You read it bro, why did you read it if you are asking questions as surface as that.
+
+It's just shoving info in your vault for no reason, but that's just my opinion. The real value add from all these
+systems come from your own writing, and I don't like having a setup that undermines that. Slop in, slop out. And I feel
+people should have the freedom to structure their wikis in ways they want, they should have the freedom over tuning the
+search algorithm as they see fit.
+
+The way a software engineer does this might not be the way a PhD student does this. A solution like gbrain might work
+very well for someone like garry tan who receives so much more inbound that a IC3 working at a tech company.
+
+I like my tools to be paint brushes and not hammers. I like the freedom to compose my systems. At least the one's that I
+interact with daily.
+
+I have been trying to offload a lot of my note-taking admin work to agents, I love writing, I love having a system that
+can manage my notes about things. Earlier it used to take a lot of my personal time maintaining this system. All that
+has changed a lot with agents.
+
+Now I can just focus on my writing and my curiosities while a cron job on my mac mini can take care of all these admin
+tasks.
+
+My ideal experience with any knowledege management system or like a note system would be something like opening a chat
+window and just doing free form brain dumps of all the things I am thinking about -- the chores list, work items,
+meetings, essay ideas etc.
+
+And then the system should be smart enough to chop up these free form brain dumps (or voice messages) and slot it into
+the right places.
+
+I am a big fan of free form writing, it's a great way to surface all the knots in your thinking and all the biases, and
+assumptions etc. All ideas sound good until you write them down.
+
+But yeah, that's my ideal note taking system, where I don't do any admin work and just focus on doing the thing.
+
+I am a big believer in BYOA (bring your own agent) architectures, the amount of flux that keeps happening in the AI
+models market, doing anything that can only work with either OpenAI models/harnesses or only Anthropic one's, that's
+just stupid. You should be able to preserve your data and it's indexes in a way that are fully harness and model
+agnostic, that would allow you to reap the benefits of all the improvements that happen at the model layer.
+
+---
+
+**Notes**
+
+Special thanks to [Komal Tiwari](https://www.linkedin.com/in/komal-t-b4662119a) and
+[Ganesh Futane](https://www.linkedin.com/in/ganeshfutane) for reading drafts of this post and providing feedback.
+
+[^1]: [Andrej Karpathy on LLM Knowledge Bases](https://x.com/karpathy/status/2039805659525644595?s=20)

--- a/content/posts/obsidian-four-year-reflections.md
+++ b/content/posts/obsidian-four-year-reflections.md
@@ -50,7 +50,7 @@ I use the following community plugins
 - [Home Tab](https://github.com/olrenso/obsidian-home-tab) for quick access to my most used notes
 - [Tag Wrangler](https://github.com/pjeby/tag-wrangler) for searching via tags and building a hierarchy of tags
 
-I also use [Obsidian Sync](https://obsidian.md/sync), mostly for a nice mobile experience. Also I *want to* pay them some money. I really want Obsidian to stick around, love their approach with being [100% user-supported](https://stephango.com/vcware).
+I also use [Obsidian Sync](https://obsidian.md/sync), mostly for a nice mobile experience. Also I _want to_ pay them some money. I really want Obsidian to stick around, love their approach with being [100% user-supported](https://stephango.com/vcware).
 
 The way my vault has evolved is by moving to simpler and simpler structures to organise my notes.
 

--- a/content/posts/smolbren-ontology-first-markdown-search.md
+++ b/content/posts/smolbren-ontology-first-markdown-search.md
@@ -135,18 +135,19 @@ around with your own way of doing CRON jobs and setting up your dreaming sequenc
 
 Test Setup: 5,000-note vault, 15,000 links.
 
-| Approach                                                                               | Agent ingests        | Turns |
-| -------------------------------------------------------------------------------------- | -------------------- | ----- |
-| `smolbren query "MATCH (b:blog)-[:mentions]->(p:project) RETURN count(DISTINCT p.id)"` | **37 bytes**         | 1     |
-| grep, naive (list blogs → pull their `mentions:` lines → count in-context)             | 610KB (~150k tokens) | 3+    |
+| Query                                                           | smolbren Cypher (1 call) | grep (agent ingests) |
+| --------------------------------------------------------------- | ------------------------ | -------------------- |
+| How many projects have a blog linking to them?                  | **198ms / 37 B**         | 611 KB over 2+ calls |
+| What does note X mention, with titles?                          | **211ms / 206 B**        | 2 KB over 2+ calls   |
+| Top-5 most-mentioned people                                     | **208ms / 205 B**        | 826 KB over 1+ calls |
+| How many projects are mentioned by both a blog _and_ a journal? | **320ms / 37 B**         | 719 KB over 2+ calls |
+| Who links to note Y, and what type is each?                     | **198ms / 136 B**        | 1 KB over 2+ calls   |
 
-| Query                                                           | smolbren Cypher   | grep (agent ingests) |
-| --------------------------------------------------------------- | ----------------- | -------------------- |
-| How many projects have a blog linking to them?                  | **198ms / 37 B**  | 611 KB over 2+ calls |
-| What does note X mention, with titles?                          | **211ms / 206 B** | 2 KB over 2+ calls   |
-| Top-5 most-mentioned people                                     | **208ms / 205 B** | 826 KB over 1+ calls |
-| How many projects are mentioned by both a blog _and_ a journal? | **320ms / 37 B**  | 719 KB over 2+ calls |
-| Who links to note Y, and what type is each?                     | **198ms / 136 B** | 1 KB over 2+ calls   |
+The first row, for example, is a single call:
+
+```sh
+smolbren query "MATCH (b:blog)-[:mentions]->(p:project) RETURN count(DISTINCT p.id)"
+```
 
 Grep costs assume the agent pulls intermediate results (file lists, frontmatter lines) into context to join them — the
 only option once links are basenames or aliases and `type` lives in frontmatter rather than the folder structure. At ~4

--- a/content/posts/smolbren-ontology-first-markdown-search.md
+++ b/content/posts/smolbren-ontology-first-markdown-search.md
@@ -149,33 +149,36 @@ The first row, for example, is a single call:
 smolbren query "MATCH (b:blog)-[:mentions]->(p:project) RETURN count(DISTINCT p.id)"
 ```
 
-Grep costs assume the agent pulls intermediate results (file lists, frontmatter lines) into context to join them — the
-only option once links are basenames or aliases and `type` lives in frontmatter rather than the folder structure. At ~4
-bytes/token, the worst rows are 150–200k tokens: a context window spent answering one question.
+To put numbers on this I generated a 5,000-note vault with 15,000 links between notes and asked five questions that need
+the graph.
+
+The smolbren column is a single Cypher query per question. The grep column is what an agent has to pull into its context
+window to answer the same question with ripgrep: list the candidate files first, then fetch their frontmatter lines,
+then do the join itself[^2].
+
+Nothing about that loop is hypothetical, it's what Claude does in my sessions when all it has is a file tree and a
+search tool. Medians over 7 runs, release builds, M-series MacBook.
 
 ## In Conclusion
 
 My hermes agent, a cron job on my mac mini, now uses smolbren to rip through my obsidian vault and make sure that things
 are as per the ontology, and if needed it grows the ontology on its own.
 
-This is also a very different approach to doing this knowledge base setup, a lot of advice on setting this up is to give
-up all of the control to the agents and let them do all the ingesting and the writing.
+This is a very different approach from most of the advice on setting up a knowledge base, which is to give up all of the
+control to the agents and let them do the ingesting and the writing -- index literally everything you see on your
+screen, every notification, email and meeting note, and then ask dumb questions like "oh tell me everything I've read
+about this topic".
 
-There is no point in having the second brain index literally everything you see on your screen and all the notifications
-or emails or meeting notes you get. And then ask it dumb questions like "oh tell me everything I've read about this
-topic".
+All that does is undermine the highest signal input the system can get, your own long form writing. Free form writing is
+what surfaces the knots in your thinking, all the biases and assumptions. All ideas sound good until you write them
+down. Shove everything else in and it's slop in, slop out.
 
-I want to preserve my own long form writing as the highest signal input to this system. I am a big fan of free form
-writing, it's a great way to surface all the knots in your thinking and all the biases and assumptions. All ideas sound
-good until you write them down. Slop in, slop out.
-
-I like my tools to be paint brushes and not hammers. I like the freedom to compose my systems. At least the ones that I
-interact with daily.
-
-I am a big believer in BYOA (bring your own agent) architectures, the amount of flux that keeps happening in the AI
-models market, doing anything that can only work with either OpenAI models/harnesses or only Anthropic one's, that's
-just stupid. You should be able to preserve your data and its indexes in a way that are fully harness and model
-agnostic, that would allow you to reap the benefits of all the improvements that happen at the model layer.
+That's also why smolbren stays a small tool and not a platform. Tools should be paint brushes and not hammers, at least
+the ones you interact with daily, and they should leave you the freedom to compose your own systems. The same freedom
+applies at the model layer, with the amount of flux in the AI models market, building anything that only works with
+OpenAI models/harnesses or only Anthropic ones is just stupid. BYOA, bring your own agent. Preserve your data and its
+indexes in a way that is fully harness and model agnostic, and you get to reap all the improvements that happen at the
+model layer.
 
 ---
 
@@ -185,3 +188,13 @@ Special thanks to [Komal Tiwari](https://www.linkedin.com/in/komal-t-b4662119a) 
 [Ganesh Futane](https://www.linkedin.com/in/ganeshfutane) for reading drafts of this post and providing feedback.
 
 [^1]: [Andrej Karpathy on LLM Knowledge Bases](https://x.com/karpathy/status/2039805659525644595?s=20)
+
+[^2]:
+    Yes, you can often do this in one pipeline and skip the context cost entirely:
+    `rg -o '\[\[people/' | sort | uniq -c | head` type stuff. I timed those too and they beat smolbren, 30–150ms. The
+    catch is they only worked because I generated this vault to be grep-friendly: every link is a full path like
+    `[[projects/note-0042]]` and the folder name always matches the note's type. My real vault has neither. Links look
+    like `[[note-0042]]` or `[[note-0042|that search thing]]`, and `type: project` lives in frontmatter while the file
+    sits in whatever folder made sense at the time. So to type-check a single link target you have to figure out which
+    file it points to and open it. Do that 15,000 times and you've rebuilt an indexer in bash, badly, and it reruns on
+    every question.

--- a/content/posts/smolbren-ontology-first-markdown-search.md
+++ b/content/posts/smolbren-ontology-first-markdown-search.md
@@ -133,13 +133,24 @@ around with your own way of doing CRON jobs and setting up your dreaming sequenc
 
 ### Performance
 
-- **Question: "How many projects have a blog linked to them?"**
-- Test Setup: 5,000-note vault, 15,000 links.
+Test Setup: 5,000-note vault, 15,000 links.
 
 | Approach                                                                               | Agent ingests        | Turns |
 | -------------------------------------------------------------------------------------- | -------------------- | ----- |
 | `smolbren query "MATCH (b:blog)-[:mentions]->(p:project) RETURN count(DISTINCT p.id)"` | **37 bytes**         | 1     |
 | grep, naive (list blogs → pull their `mentions:` lines → count in-context)             | 610KB (~150k tokens) | 3+    |
+
+| Query                                                           | smolbren Cypher   | grep (agent ingests) |
+| --------------------------------------------------------------- | ----------------- | -------------------- |
+| How many projects have a blog linking to them?                  | **198ms / 37 B**  | 611 KB over 2+ calls |
+| What does note X mention, with titles?                          | **211ms / 206 B** | 2 KB over 2+ calls   |
+| Top-5 most-mentioned people                                     | **208ms / 205 B** | 826 KB over 1+ calls |
+| How many projects are mentioned by both a blog _and_ a journal? | **320ms / 37 B**  | 719 KB over 2+ calls |
+| Who links to note Y, and what type is each?                     | **198ms / 136 B** | 1 KB over 2+ calls   |
+
+Grep costs assume the agent pulls intermediate results (file lists, frontmatter lines) into context to join them — the
+only option once links are basenames or aliases and `type` lives in frontmatter rather than the folder structure. At ~4
+bytes/token, the worst rows are 150–200k tokens: a context window spent answering one question.
 
 ## In Conclusion
 

--- a/content/posts/smolbren-ontology-first-markdown-search.md
+++ b/content/posts/smolbren-ontology-first-markdown-search.md
@@ -161,24 +161,24 @@ search tool. Medians over 7 runs, release builds, M-series MacBook.
 
 ## In Conclusion
 
-My hermes agent, a cron job on my mac mini, now uses smolbren to rip through my obsidian vault and make sure that things
-are as per the ontology, and if needed it grows the ontology on its own.
+My hermes agent now uses smolbren to search through my obsidian vault and make sure that things are as per the ontology,
+and if needed it grows the ontology on its own.
 
 This is a very different approach from most of the advice on setting up a knowledge base, which is to give up all of the
-control to the agents and let them do the ingesting and the writing -- index literally everything you see on your
-screen, every notification, email and meeting note, and then ask dumb questions like "oh tell me everything I've read
-about this topic".
+control to the agents and let them do the ingesting and the writing. I have also seen tools that index literally
+everything you see on your screen, every notification, email and meeting note and that seems a bit unnecessary.
 
-All that does is undermine the highest signal input the system can get, your own long form writing. Free form writing is
-what surfaces the knots in your thinking, all the biases and assumptions. All ideas sound good until you write them
-down. Shove everything else in and it's slop in, slop out.
+All that does is undermine the highest signal input to the system which is your own long form writing, that's what
+surfaces the knots in your thinking, all the biases and assumptions. All ideas sound good until you write them down.
+Shove everything else in and it's slop in, slop out.
 
 That's also why smolbren stays a small tool and not a platform. Tools should be paint brushes and not hammers, at least
 the ones you interact with daily, and they should leave you the freedom to compose your own systems. The same freedom
 applies at the model layer, with the amount of flux in the AI models market, building anything that only works with
-OpenAI models/harnesses or only Anthropic ones is just stupid. BYOA, bring your own agent. Preserve your data and its
-indexes in a way that is fully harness and model agnostic, and you get to reap all the improvements that happen at the
-model layer.
+OpenAI models/harnesses or only Anthropic ones is just stupid.
+
+BYOA, bring your own agent. Preserve your data and its indexes in a way that is fully harness and model agnostic, and
+you get to reap all the improvements that happen at the model layer.
 
 ---
 

--- a/content/posts/smolbren-ontology-first-markdown-search.md
+++ b/content/posts/smolbren-ontology-first-markdown-search.md
@@ -1,8 +1,12 @@
 ---
-title: "smolbren: Ontology first search over Markdown"
+title: "smolbren: Ontology-first Search over Markdown"
 date: "2026-07-03T13:12:58+05:30"
-summary: ""
-description: "How to manage a vault of markdown notes in an ontology first fashion."
+summary:
+  "Why I stopped letting agents grep through 13k notes and built smolbren: ontology-first search over markdown
+  frontmatter."
+description:
+  "Why I stopped letting agents grep through 13k notes and built smolbren: ontology-first search over markdown
+  frontmatter."
 toc: true
 readTime: true
 autonumber: false
@@ -10,19 +14,20 @@ math: true
 draft: false
 ---
 
-> **tldr**; this about a tool I wrote called [smolbren](http://github.com/junaidrahim/smolbren) to make ontology driven
-> agentic search faster and token-efficient over my obsidian vault (~13k notes).
+> **tldr**; this is about a tool I wrote called [smolbren](https://github.com/junaidrahim/smolbren) to make
+> ontology-driven agentic search faster and token-efficient over my obsidian vault (~13k notes).
 
-If you've setup a LLM driven knowledge base[^1], one of the very first things you ask your agent to do is to go over
+If you've set up an LLM driven knowledge base[^1], one of the very first things you ask your agent to do is to go over
 your vault and come up with some sort of a schema, a set of types for the documents that go into your vault.
 
 You might write it as a skill or just add it as a prompt that whenever you are processing a bunch of text, try to figure
 out what type should be attached to this note.
 
-Types would be things like `recipe`, `idea`, `algorithm`, `essay`, `person`, `company`, `device`, `book` etc,
+Types would be things like `recipe`, `idea`, `algorithm`, `essay`, `person`, `company`, `device`, `book` etc.
 
 This is what enables your agent to make organising decisions, and that was the essence of Karpathy's post, to hand over
-most of the admin work of maintaing a knowledge base to an agent by writing down these principles in skills or prompts.
+most of the admin work of maintaining a knowledge base to an agent by writing down these principles in skills or
+prompts.
 
 After you have types in your vault, and you are using something like Obsidian that allows wikilinks between notes, you
 can also define how edges should be created between the notes.
@@ -53,7 +58,7 @@ An ambiguous utopia: two worlds, one wall, and the physicist who tries to unbuil
 I used markdown frontmatter to encode all the things that are required for the ontology, the `type` key denotes the type
 of the note and relationships are arbitrary keys with list of wikilinks.
 
-This is what the graph would for the note and it's linked notes would look like.
+This is what the graph for this note and its linked notes looks like.
 
 ```mermaid
 graph LR
@@ -83,7 +88,7 @@ graph LR
     book -->|"related"| book
 ```
 
-I also clip a lot of web articles using the obsidian web clipper and you frequently ask agents to research a topic and
+I also clip a lot of web articles using the obsidian web clipper and I frequently ask agents to research a topic and
 keep a few markdown files ready for me to review, naturally my vault grew by ~6x in terms of number of notes.
 
 ## Introducing `smolbren`
@@ -99,24 +104,23 @@ I named it `smolbren`, because it's truly a very small brain that you can add to
 it in specific ways to make search more token efficient.
 
 `smolbren` is written in rust using lancedb for storage and lance-graph for implementing the Cypher query language, I
-used [embeddinggemma-300M-Q8_0](https://huggingface.co/google/embeddinggemma-300m-qat-q8_0-unquantized) for vector
-embeddings.
+used a quantized ONNX build of [EmbeddingGemma-300M](https://huggingface.co/onnx-community/embeddinggemma-300m-ONNX) for
+vector embeddings.
 
 You can read the docs at [smolbren.com](https://smolbren.com/). Or you can give the following prompt to your agent
 
 ```markdown
-Read the docs at https://smolbren.com, mainly the installation and quickstart pages,
-and set up smolbren on this machine for my markdown vault.
+Read the docs at https://smolbren.com, mainly the installation and quickstart pages, and set up smolbren on this machine
+for my markdown vault.
 
-1. Check the prerequisites first -- a Rust toolchain (1.85+) and protoc on PATH.
-   Install whatever is missing (rustup for Rust, `brew install protobuf` on macOS
-   or `apt-get install protobuf-compiler` on Linux).
+1. Check the prerequisites first -- a Rust toolchain (1.85+) and protoc on PATH. Install whatever is missing (rustup for
+   Rust, `brew install protobuf` on macOS or `apt-get install protobuf-compiler` on Linux).
 2. Install it with `cargo install smolbren` and verify with `smolbren --version`.
-3. My vault lives at <path-to-your-vault>. Register it with
-   `smolbren vault add personal <path>` and run `smolbren index`.
-4. Show me the ontology it discovered -- run `smolbren types` and `smolbren edges`
-   and summarize what note types and relationships exist in my vault.
-5. Sanity check the search: run one `smolbren search` and one `smolbren query`
+3. My vault lives at <path-to-your-vault>. Register it with `smolbren vault add personal <path-to-your-vault>` and run
+   `smolbren index` followed by `smolbren embed`.
+4. Show me the ontology it discovered -- run `smolbren types` and `smolbren edges` and summarize what note types and
+   relationships exist in my vault.
+5. Sanity check the search: run one `smolbren search` (BM25), one `smolbren similar` (vector) and one `smolbren query`
    (Cypher) that are relevant to my notes and show me the raw output.
 
 If anything fails, read the relevant page on smolbren.com before retrying.
@@ -139,53 +143,26 @@ around with your own way of doing CRON jobs and setting up your dreaming sequenc
 
 ## In Conclusion
 
-My hermes agent now uses smolbren to rip through my obsidian vault and make sure that things are as per the ontology,
-and if needed it grows the ontology on it's own.
+My hermes agent, a cron job on my mac mini, now uses smolbren to rip through my obsidian vault and make sure that things
+are as per the ontology, and if needed it grows the ontology on its own.
 
-This is also a very different approach to doing the second brain thing, I imagine this whole thing as a spectrum, where
-on one hand you could fully analog raw dog it and write everything on yourself and manually store things in specific
-files.
+This is also a very different approach to doing this knowledge base setup, a lot of advice on setting this up is to give
+up all of the control to the agents and let them do all the ingesting and the writing.
 
-You could also try a bunch of other second brain solutions which I feel deeply undermine the highest signal you can give
-to your setup which is your own long form writing. There is no point in having the second brain index literally
-everything you see on your screen and all the notifications or emails or meetings notes you get. And then ask it dumb
-questions like "oh tell me everything I've read about this topic".
+There is no point in having the second brain index literally everything you see on your screen and all the notifications
+or emails or meeting notes you get. And then ask it dumb questions like "oh tell me everything I've read about this
+topic".
 
-You read it bro, why did you read it if you are asking questions as surface as that.
+I want to preserve my own long form writing as the highest signal input to this system. I am a big fan of free form
+writing, it's a great way to surface all the knots in your thinking and all the biases and assumptions. All ideas sound
+good until you write them down. Slop in, slop out.
 
-It's just shoving info in your vault for no reason, but that's just my opinion. The real value add from all these
-systems come from your own writing, and I don't like having a setup that undermines that. Slop in, slop out. And I feel
-people should have the freedom to structure their wikis in ways they want, they should have the freedom over tuning the
-search algorithm as they see fit.
-
-The way a software engineer does this might not be the way a PhD student does this. A solution like gbrain might work
-very well for someone like garry tan who receives so much more inbound that a IC3 working at a tech company.
-
-I like my tools to be paint brushes and not hammers. I like the freedom to compose my systems. At least the one's that I
+I like my tools to be paint brushes and not hammers. I like the freedom to compose my systems. At least the ones that I
 interact with daily.
-
-I have been trying to offload a lot of my note-taking admin work to agents, I love writing, I love having a system that
-can manage my notes about things. Earlier it used to take a lot of my personal time maintaining this system. All that
-has changed a lot with agents.
-
-Now I can just focus on my writing and my curiosities while a cron job on my mac mini can take care of all these admin
-tasks.
-
-My ideal experience with any knowledege management system or like a note system would be something like opening a chat
-window and just doing free form brain dumps of all the things I am thinking about -- the chores list, work items,
-meetings, essay ideas etc.
-
-And then the system should be smart enough to chop up these free form brain dumps (or voice messages) and slot it into
-the right places.
-
-I am a big fan of free form writing, it's a great way to surface all the knots in your thinking and all the biases, and
-assumptions etc. All ideas sound good until you write them down.
-
-But yeah, that's my ideal note taking system, where I don't do any admin work and just focus on doing the thing.
 
 I am a big believer in BYOA (bring your own agent) architectures, the amount of flux that keeps happening in the AI
 models market, doing anything that can only work with either OpenAI models/harnesses or only Anthropic one's, that's
-just stupid. You should be able to preserve your data and it's indexes in a way that are fully harness and model
+just stupid. You should be able to preserve your data and its indexes in a way that are fully harness and model
 agnostic, that would allow you to reap the benefits of all the improvements that happen at the model layer.
 
 ---


### PR DESCRIPTION
## Summary

- New post: **smolbren: Ontology-first Search over Markdown** (`content/posts/smolbren-ontology-first-markdown-search.md`) — ontology-first note-taking with markdown frontmatter, and the launch write-up for [smolbren](https://smolbren.com). Includes two mermaid diagrams (note-level graph + type-level ontology), a paste-able agent prompt covering install → index → embed → all three search modes (BM25 / vector / Cypher), and a benchmark table (5k-note vault) comparing single-call Cypher queries against agent-driven grep loops.
- **CSS fix**: the site's fork of the theme's `main.css` was missing the `:root` block mapping `--content-primary/secondary`, `--background`, `--code-background`, `--code-border` via `light-dark()` (dropped during a theme palette refactor). This made `<hr>` elements render invisible, among other things. Restored the block verbatim from the theme.
- **Table styling**: tables now render with uniform 1px gray cell borders (no rounded corners); the border is drawn by cells only, since the reset's `display: block` on tables prevents the table's own border from collapsing with cell borders.
- **Tooling**: `.prettierrc` wrapping markdown prose at 120 chars, plus the resulting reflow of three content files.

## Test plan

- `hugo` builds cleanly; verified the bundled CSS defines `--content-secondary` and the `hr` / table rules resolve.
- Previewed the post with `hugo server`: mermaid diagrams, table borders, and horizontal rules all render.
- Post claims verified against the smolbren repo (similarity search merged in #8, EmbeddingGemma-300M Q4 ONNX via fastembed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)